### PR TITLE
Handle language paths

### DIFF
--- a/graphs/utils.py
+++ b/graphs/utils.py
@@ -18,6 +18,10 @@ def normalize_mediawiki_url(url):
     :rtype: str
     :raise: ValueError
     """
+    # remove language path
+    if not url.startswith('/wiki/'):
+        url = re.sub(r'^/[a-z\-]{2,14}/', '/', url)
+
     parsed = urlparse(url)
     query_params = parse_qs(parsed.query)
 

--- a/test/test_normalize_url.py
+++ b/test/test_normalize_url.py
@@ -31,6 +31,16 @@ def test_normalize_mediawiki_url():
     assert normalize_mediawiki_url('/wiki/Special:HealthCheck') == \
         'mediawiki:Special:HealthCheck'
 
+    # language path
+    assert normalize_mediawiki_url('/szl/api.php?action=query&format=json&list=users&usids=11536%7C25314808&usprop=groups%7Crights%7Cblockinfo') == \
+        'api:query::users'
+
+    assert normalize_mediawiki_url('/is/wiki/Special:HealthCheck') == \
+        'mediawiki:Special:HealthCheck'
+
+    assert normalize_mediawiki_url('/pt-br/wikia.php/?method=handle&controller=Email%5CController%5CDiscussionReply') == \
+        'nirvana:EmailControllerDiscussionReply::handle'
+
 
 def test_normalize_pandora_url():
     # service URLs


### PR DESCRIPTION
Avoid the following:

```
Traceback (most recent call last):
  File "/opt/wikia/data-flow-graphs/env/bin/http_pandora_mediawiki", line 11, in <module>
    load_entry_point('graphs', 'console_scripts', 'http_pandora_mediawiki')()
  File "/opt/wikia/data-flow-graphs/graphs/http_pandora_mediawiki.py", line 208, in main
    http_mw = get_mediawiki_flow_graph(limit=50000, period=3600)
  File "/opt/wikia/data-flow-graphs/graphs/http_pandora_mediawiki.py", line 43, in get_mediawiki_flow_graph
    for row in rows
  File "/opt/wikia/data-flow-graphs/graphs/http_pandora_mediawiki.py", line 43, in <listcomp>
    for row in rows
  File "/opt/wikia/data-flow-graphs/graphs/utils.py", line 41, in normalize_mediawiki_url
    raise ValueError('Provided URL <%s> has not been matched' % url)
ValueError: Provided URL </szl/api.php?action=query&format=json&list=users&usids=11536%7C25314808&usprop=groups%7Crights%7Cblockinfo> has not been matched
```